### PR TITLE
Refactor: 분산 멀티 스레드 환경에서 쿼리 병합 전략 적용

### DIFF
--- a/src/main/java/com/newzet/api/common/DistributedRequestMerger.java
+++ b/src/main/java/com/newzet/api/common/DistributedRequestMerger.java
@@ -1,0 +1,46 @@
+package com.newzet.api.common;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.springframework.stereotype.Component;
+
+import com.newzet.api.common.mutex.MutexFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DistributedRequestMerger<T> {
+	private final MutexFactory mutexFactory;
+	private final Map<String, CompletableFuture<T>> futureMap = new ConcurrentHashMap<>();
+
+	public T merge(String key, long waitTime, long leaseTime, Supplier<T> loader, Supplier<T> fallback) {
+		CompletableFuture<T> future = futureMap.computeIfAbsent(key, k -> {
+			CompletableFuture<T> f = new CompletableFuture<>();
+			CompletableFuture.runAsync(() -> {
+				try {
+					mutexFactory.tryMutex(key, waitTime, leaseTime);
+					try {
+						T result = loader.get();
+						f.complete(result);
+					} finally {
+						mutexFactory.release(key);
+					}
+				} catch (Exception e) {
+					log.warn("mutex 획득 실패 key {}, fallback 적용", key);
+					f.complete(fallback.get());
+				} finally {
+					futureMap.remove(key);
+				}
+			});
+			return f;
+		});
+
+		return future.join();
+	}
+}

--- a/src/main/java/com/newzet/api/common/cache/HybridCacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/HybridCacheUtil.java
@@ -6,8 +6,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import com.newzet.api.common.cache.local.LocalCacheUtil;
-import com.newzet.api.common.cache.redis.RedisServerException;
-import com.newzet.api.common.cache.redis.RedisUtil;
+import com.newzet.api.common.redis.RedisServerException;
+import com.newzet.api.common.redis.RedisStringUtil;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,13 +17,13 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class HybridCacheUtil implements CacheUtil {
-	private final RedisUtil redisUtil;
+	private final RedisStringUtil redisStringUtil;
 	private final LocalCacheUtil localCacheUtil;
 
 	@Override
 	public <T> Optional<T> get(String key, Class<T> classType) {
 		try {
-			return redisUtil.get(key, classType);
+			return redisStringUtil.get(key, classType);
 		} catch (RedisServerException e) {
 			return localCacheUtil.get(key, classType);
 		}
@@ -32,7 +32,7 @@ public class HybridCacheUtil implements CacheUtil {
 	@Override
 	public <T> void set(String key, T object, long ttl) {
 		try {
-			redisUtil.set(key, object, ttl);
+			redisStringUtil.set(key, object, ttl);
 		} catch (RedisServerException e) {
 			localCacheUtil.set(key, object, ttl);
 		}

--- a/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/redis/RedisUtil.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import com.newzet.api.common.cache.CacheUtil;
+import com.newzet.api.common.mutex.MutexUtil;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class RedisUtil implements CacheUtil {
+public class RedisUtil implements CacheUtil, MutexUtil {
 	private static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
 
 	private final RedisTemplate<String, String> redisTemplate;
@@ -42,5 +43,17 @@ public class RedisUtil implements CacheUtil {
 			log.error("[RedisUtil]: Redis 값 저장 실패, key: {}, error: {}", key, e.getMessage());
 			throw new RedisServerException();
 		}
+	}
+
+	@Override
+	public boolean setMutex(String key, String value, long ttl) {
+		Boolean result = redisTemplate.opsForValue()
+			.setIfAbsent(key, value, ttl, TIME_UNIT);
+		return Boolean.TRUE.equals(result);
+	}
+
+	@Override
+	public void delete(String key) {
+		redisTemplate.delete(key);
 	}
 }

--- a/src/main/java/com/newzet/api/common/mutex/MutexAcquisitionException.java
+++ b/src/main/java/com/newzet/api/common/mutex/MutexAcquisitionException.java
@@ -1,0 +1,7 @@
+package com.newzet.api.common.mutex;
+
+public class MutexAcquisitionException extends RuntimeException{
+	public MutexAcquisitionException() {
+		super();
+	}
+}

--- a/src/main/java/com/newzet/api/common/mutex/MutexFactory.java
+++ b/src/main/java/com/newzet/api/common/mutex/MutexFactory.java
@@ -1,0 +1,7 @@
+package com.newzet.api.common.mutex;
+
+public interface MutexFactory {
+	public void tryMutex(String key, long waitTime, long leaseTime);
+
+	public void release(String key);
+}

--- a/src/main/java/com/newzet/api/common/mutex/MutexUtil.java
+++ b/src/main/java/com/newzet/api/common/mutex/MutexUtil.java
@@ -1,0 +1,7 @@
+package com.newzet.api.common.mutex;
+
+public interface MutexUtil {
+	public boolean setMutex(String key, String value, long ttl);
+
+	public void delete(String key);
+}

--- a/src/main/java/com/newzet/api/common/mutex/RedisMutexFactory.java
+++ b/src/main/java/com/newzet/api/common/mutex/RedisMutexFactory.java
@@ -2,8 +2,6 @@ package com.newzet.api.common.mutex;
 
 import org.springframework.stereotype.Component;
 
-import com.newzet.api.common.cache.redis.RedisUtil;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,7 +14,7 @@ public class RedisMutexFactory implements MutexFactory{
 	private static final String MUTEX_PREFIX = "mutex:";
 	private static final String MUTEX_VALUE = "locked";
 
-	private final RedisUtil redisUtil;
+	private final MutexUtil mutexUtil;
 
 	@Override
 	public void tryMutex(String key, long waitTime, long leaseTime) {
@@ -24,7 +22,7 @@ public class RedisMutexFactory implements MutexFactory{
 		long endTime = startTime + waitTime;
 
 		while (System.currentTimeMillis() < endTime) {
-			boolean acquired = redisUtil.setMutex(MUTEX_PREFIX + key, MUTEX_VALUE, leaseTime);
+			boolean acquired = mutexUtil.setMutex(MUTEX_PREFIX + key, MUTEX_VALUE, leaseTime);
 			if (acquired) return;
 
 			try {
@@ -38,7 +36,7 @@ public class RedisMutexFactory implements MutexFactory{
 
 	@Override
 	public void release(String key) {
-		redisUtil.delete(MUTEX_PREFIX + key);
+		mutexUtil.delete(MUTEX_PREFIX + key);
 	}
 }
 

--- a/src/main/java/com/newzet/api/common/mutex/RedisMutexFactory.java
+++ b/src/main/java/com/newzet/api/common/mutex/RedisMutexFactory.java
@@ -1,0 +1,44 @@
+package com.newzet.api.common.mutex;
+
+import org.springframework.stereotype.Component;
+
+import com.newzet.api.common.cache.redis.RedisUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisMutexFactory implements MutexFactory{
+
+	private static final long MUTEX_ACQUISITION_INTERVAL_MS = 300;
+	private static final String MUTEX_PREFIX = "mutex:";
+	private static final String MUTEX_VALUE = "locked";
+
+	private final RedisUtil redisUtil;
+
+	@Override
+	public void tryMutex(String key, long waitTime, long leaseTime) {
+		long startTime = System.currentTimeMillis();
+		long endTime = startTime + waitTime;
+
+		while (System.currentTimeMillis() < endTime) {
+			boolean acquired = redisUtil.setMutex(MUTEX_PREFIX + key, MUTEX_VALUE, leaseTime);
+			if (acquired) return;
+
+			try {
+				Thread.sleep(MUTEX_ACQUISITION_INTERVAL_MS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		throw new MutexAcquisitionException();
+	}
+
+	@Override
+	public void release(String key) {
+		redisUtil.delete(MUTEX_PREFIX + key);
+	}
+}
+

--- a/src/main/java/com/newzet/api/common/redis/RedisServerException.java
+++ b/src/main/java/com/newzet/api/common/redis/RedisServerException.java
@@ -1,4 +1,4 @@
-package com.newzet.api.common.cache.redis;
+package com.newzet.api.common.redis;
 
 public class RedisServerException extends RuntimeException {
 	public RedisServerException() {

--- a/src/main/java/com/newzet/api/common/redis/RedisStringUtil.java
+++ b/src/main/java/com/newzet/api/common/redis/RedisStringUtil.java
@@ -1,4 +1,4 @@
-package com.newzet.api.common.cache.redis;
+package com.newzet.api.common.redis;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class RedisUtil implements CacheUtil, MutexUtil {
+public class RedisStringUtil implements CacheUtil, MutexUtil {
 	private static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
 
 	private final RedisTemplate<String, String> redisTemplate;

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterCacheService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterCacheService.java
@@ -1,0 +1,30 @@
+package com.newzet.api.newsletter.business;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.newzet.api.common.cache.CacheUtil;
+import com.newzet.api.newsletter.business.dto.NewsletterCacheDto;
+import com.newzet.api.newsletter.domain.Newsletter;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NewsletterCacheService {
+
+	private static final Long CACHE_DURATION = 1000 * 60 * 5L;
+	private static final String CACHE_PREFIX = "cache:";
+
+	private final CacheUtil cacheUtil;
+
+	public Optional<Newsletter> findOnCache(String key) {
+		return cacheUtil.get(CACHE_PREFIX + key, NewsletterCacheDto.class)
+			.map(NewsletterCacheDto::toDomain);
+	}
+
+	public void saveOnCache(String key, Newsletter newsletter) {
+		cacheUtil.set(CACHE_PREFIX + key, newsletter.toCacheDto(), CACHE_DURATION);
+	}
+}

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
@@ -1,14 +1,10 @@
 package com.newzet.api.newsletter.business;
 
-import java.util.Optional;
-import java.util.concurrent.locks.Lock;
-
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.newzet.api.common.cache.CacheUtil;
-import com.newzet.api.common.lock.LockFactory;
-import com.newzet.api.newsletter.business.dto.NewsletterCacheDto;
+import com.newzet.api.common.DistributedRequestMerger;
 import com.newzet.api.newsletter.business.dto.NewsletterEntityDto;
 import com.newzet.api.newsletter.domain.Newsletter;
 import com.newzet.api.newsletter.domain.NewsletterStatus;
@@ -22,55 +18,42 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NewsletterService {
 
-	private static final Long CACHE_LOCK_WAIT_TIME = 1000 * 5L;
-	private static final Long CACHE_LOCK_LEASE_TIME = 1000 * 3L;
-	private static final Long CACHE_DURATION = 1000 * 60 * 5L;
-	private static final String CACHE_DOMAIN_PREFIX = "newsletter:domain";
+	private static final String NEWSLETTER_DOMAIN_PREFIX = "newsletter:domain:";
+	private static final Long MUTEX_WAIT_TIME = 5000L;
+	private static final Long MUTEX_LEASE_TIME = 3000L;
 
 	private final NewsletterRepository newsletterRepository;
-	private final CacheUtil cacheUtil;
-	private final LockFactory lockFactory;
+	private final NewsletterCacheService cacheService;
+	private final DistributedRequestMerger<Newsletter> distributedRequestMerger;
 
 	public Newsletter findOrCreateNewsletter(String name, String domain, String mailingList) {
-		return findByDomainOnCache(domain)
-			.orElseGet(() -> findOrCreateByDomainOrMailingListWithLock(name, domain, mailingList));
-	}
-
-	private Optional<Newsletter> findByDomainOnCache(String domain) {
-		return cacheUtil.get(CACHE_DOMAIN_PREFIX + domain, NewsletterCacheDto.class)
-			.map(dto -> Newsletter.create(dto.getId(), dto.getName(), dto.getDomain(),
-				dto.getMailingList(), dto.getStatus()));
-	}
-
-	private Newsletter findOrCreateByDomainOrMailingListWithLock(String name, String domain,
-		String mailingList) {
-		Lock lock = lockFactory.tryLock(CACHE_DOMAIN_PREFIX + ":" + domain,
-			CACHE_LOCK_WAIT_TIME, CACHE_LOCK_LEASE_TIME);
-
-		try {
-			return findByDomainOnCache(domain).orElseGet(
-				() -> findOrCreateByDomainOrMailingListInDatabase(name, domain, mailingList));
-		} finally {
-			lockFactory.unlock(lock);
-		}
+		return cacheService.findOnCache(domain)
+			.orElseGet(() ->
+				distributedRequestMerger.merge(
+					NEWSLETTER_DOMAIN_PREFIX + domain, MUTEX_WAIT_TIME, MUTEX_LEASE_TIME,
+					() -> {return findOrCreateNewsletter(name, domain, mailingList);},
+					() -> {return findOrCreateNewsletter(name, domain, mailingList);})
+				);
 	}
 
 	private Newsletter findOrCreateByDomainOrMailingListInDatabase(String name, String domain,
 		String mailingList) {
-		return newsletterRepository
-			.findByDomainOrMailingList(domain, mailingList)
+		Newsletter newsletter = newsletterRepository
+			.findByDomainOrMailingList(NEWSLETTER_DOMAIN_PREFIX + domain, mailingList)
 			.map(NewsletterEntityDto::toDomain)
-			.map(newsletter -> {
-				cacheUtil.set(CACHE_DOMAIN_PREFIX + domain, newsletter.toCacheDto(), CACHE_DURATION);
-				return newsletter;
-			})
 			.orElseGet(() -> createNewsletter(name, domain, mailingList));
+		cacheService.saveOnCache(NEWSLETTER_DOMAIN_PREFIX + domain, newsletter);
+		return newsletter;
 	}
 
 	private Newsletter createNewsletter(String name, String domain, String mailingList) {
-		Newsletter savedNewsletter = newsletterRepository.save(name, domain, mailingList,
-			NewsletterStatus.UNREGISTERED.name()).toDomain();
-		cacheUtil.set(CACHE_DOMAIN_PREFIX + domain, savedNewsletter.toCacheDto(), CACHE_DURATION);
-		return savedNewsletter;
+		try {
+			return newsletterRepository.save(name, domain, mailingList, NewsletterStatus.UNREGISTERED.name())
+				.toDomain();
+		} catch (DuplicateKeyException e) {
+			return newsletterRepository.findByDomainOrMailingList(domain, mailingList)
+				.map(NewsletterEntityDto::toDomain)
+				.orElseThrow(() -> new IllegalStateException("Insert 실패 후 조회도 실패"));
+		}
 	}
 }

--- a/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
+++ b/src/main/java/com/newzet/api/newsletter/business/NewsletterService.java
@@ -31,8 +31,8 @@ public class NewsletterService {
 			.orElseGet(() ->
 				distributedRequestMerger.merge(
 					NEWSLETTER_DOMAIN_PREFIX + domain, MUTEX_WAIT_TIME, MUTEX_LEASE_TIME,
-					() -> {return findOrCreateNewsletter(name, domain, mailingList);},
-					() -> {return findOrCreateNewsletter(name, domain, mailingList);})
+					() -> findOrCreateByDomainOrMailingListInDatabase(name, domain, mailingList),
+					() -> findOrCreateByDomainOrMailingListInDatabase(name, domain, mailingList))
 				);
 	}
 

--- a/src/main/java/com/newzet/api/newsletter/business/dto/NewsletterCacheDto.java
+++ b/src/main/java/com/newzet/api/newsletter/business/dto/NewsletterCacheDto.java
@@ -1,5 +1,7 @@
 package com.newzet.api.newsletter.business.dto;
 
+import com.newzet.api.newsletter.domain.Newsletter;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,5 +26,9 @@ public class NewsletterCacheDto {
 			.mailingList(mailingList)
 			.status(status)
 			.build();
+	}
+
+	public Newsletter toDomain() {
+		return Newsletter.create(id, name, domain, mailingList, status);
 	}
 }

--- a/src/test/java/com/newzet/api/common/cache/HybridCacheUtilTest.java
+++ b/src/test/java/com/newzet/api/common/cache/HybridCacheUtilTest.java
@@ -12,13 +12,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.newzet.api.common.cache.local.LocalCacheUtil;
-import com.newzet.api.common.cache.redis.RedisServerException;
-import com.newzet.api.common.cache.redis.RedisUtil;
+import com.newzet.api.common.redis.RedisServerException;
+import com.newzet.api.common.redis.RedisStringUtil;
 
 @ExtendWith(MockitoExtension.class)
 public class HybridCacheUtilTest {
 	@Mock
-	RedisUtil redisUtil;
+	RedisStringUtil redisUtil;
 
 	@Mock
 	LocalCacheUtil localCacheUtil;

--- a/src/test/java/com/newzet/api/common/cache/RedisStringUtilTest.java
+++ b/src/test/java/com/newzet/api/common/cache/RedisStringUtilTest.java
@@ -13,17 +13,17 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.newzet.api.common.cache.redis.RedisUtil;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
+import com.newzet.api.common.redis.RedisStringUtil;
 import com.newzet.api.config.RedisTestContainerConfig;
 
 @DataRedisTest
-@Import({ObjectMapper.class, OptionalObjectMapper.class, RedisUtil.class})
+@Import({ObjectMapper.class, OptionalObjectMapper.class, RedisStringUtil.class})
 @ExtendWith(RedisTestContainerConfig.class)
-class RedisUtilTest {
+class RedisStringUtilTest {
 
 	@Autowired
-	private RedisUtil redisUtil;
+	private RedisStringUtil redisStringUtil;
 
 	@Autowired
 	private RedisTemplate<String, String> redisTemplate;
@@ -40,13 +40,13 @@ class RedisUtilTest {
 		String value = "testValue";
 		long ttl = 60000L;
 
-		assertFalse(redisUtil.get(key, String.class).isPresent());
+		assertFalse(redisStringUtil.get(key, String.class).isPresent());
 
 		//When
-		redisUtil.set(key, value, ttl);
+		redisStringUtil.set(key, value, ttl);
 
 		//Then
-		assertTrue(redisUtil.get(key, String.class).isPresent());
+		assertTrue(redisStringUtil.get(key, String.class).isPresent());
 	}
 
 	@Test
@@ -56,15 +56,15 @@ class RedisUtilTest {
 		String value = "testValue";
 		long ttl = 1000L;
 
-		redisUtil.set(key, value, ttl);
-		assertTrue(redisUtil.get(key, String.class).isPresent());
+		redisStringUtil.set(key, value, ttl);
+		assertTrue(redisStringUtil.get(key, String.class).isPresent());
 
 		//When
-		redisUtil.set(key, value, 3000L);
+		redisStringUtil.set(key, value, 3000L);
 
 		// Then
 		Thread.sleep(1000L);
-		assertTrue(redisUtil.get(key, String.class).isPresent());
+		assertTrue(redisStringUtil.get(key, String.class).isPresent());
 	}
 
 	@Test
@@ -75,7 +75,7 @@ class RedisUtilTest {
 		long ttl = 60000L;
 
 		//When
-		Optional<String> returnValue = redisUtil.get(key, String.class);
+		Optional<String> returnValue = redisStringUtil.get(key, String.class);
 
 		//Then
 		assertEquals(Optional.empty(), returnValue);
@@ -89,8 +89,8 @@ class RedisUtilTest {
 		long ttl = 3000L;
 
 		//When
-		redisUtil.set(key, value, ttl);
-		Optional<String> returnValue = redisUtil.get(key, String.class);
+		redisStringUtil.set(key, value, ttl);
+		Optional<String> returnValue = redisStringUtil.get(key, String.class);
 
 		//Then
 		assertTrue(returnValue.isPresent());

--- a/src/test/java/com/newzet/api/common/lock/RedisLockFactoryTest.java
+++ b/src/test/java/com/newzet/api/common/lock/RedisLockFactoryTest.java
@@ -12,16 +12,16 @@ import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
 import org.springframework.context.annotation.Import;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.newzet.api.common.cache.redis.RedisUtil;
 import com.newzet.api.common.lock.exception.RedisLockAcquisitionException;
 import com.newzet.api.common.lock.redis.RedisLock;
 import com.newzet.api.common.lock.redis.RedisLockFactory;
 import com.newzet.api.common.objectMapper.OptionalObjectMapper;
+import com.newzet.api.common.redis.RedisStringUtil;
 import com.newzet.api.config.RedisTestContainerConfig;
 import com.newzet.api.config.RedissonConfig;
 
 @DataRedisTest
-@Import({ObjectMapper.class, OptionalObjectMapper.class, RedisUtil.class, RedisLockFactory.class,
+@Import({ObjectMapper.class, OptionalObjectMapper.class, RedisStringUtil.class, RedisLockFactory.class,
 	RedissonConfig.class})
 @ExtendWith(RedisTestContainerConfig.class)
 class RedisLockFactoryTest {


### PR DESCRIPTION
# 개요

- CompletableFuture와 Mutex를 통해 분산 멀티스레드 환경에서 DB 부하 감소를 더 적은 리소스로 수행하도록 변경

# 배경

1. 기존에 DB 접근 제한을 위해 Redisson 분산 락을 사용하고 있었는데, 이를 위해서는 Mutex 값을 두고 처리하는 것이 더 간단함
2. Redis 장애 시 Local Cache로 이전되는 fail over HybridCache 구조는 Redis 장애에 대응할 수 있지만, 평상시에는 Local Cache의 리소스가 사용되지 않고 낭비된다는 문제가 있음
3. Redis 캐시를 도입해서 DB의 부하를 막긴 했지만, 멀티 스레드 환경에서 Redis 또는 local cache로 모든 쿼리 요청이 전달됨.

# 변경된 점

### 1. Redis에 Mutex 생성 및 삭제 기능 추가
- 분산 환경에 적합한 Redis Mutex를 사용하고, SetIfAbsent로 mutex 생성 기능 추가
- waitTime과 leaseTime은 다양하게 사용 가능하도록 외부 주입 (newsletter: waitTime 5초, leasTime 3초)
- commit: [Mutex 인터페이스 생성](https://github.com/Gyu-won/Newzet-Spring-Server/commit/1cc81fbb7f9980436622d19c0c21fbd6c1a3aa82), [RedisUtil에 Mutex 기능 추가](https://github.com/Gyu-won/Newzet-Spring-Server/commit/6b1663bf01c07e9a2a1a232d1a19b2e5910b4842)

### 2. MutexFactory 추가
- Mutex 획득 대기는 polling 구조로 300ms 마다 시도하도록 구현
- 테스트환경에서 모니터링을 통해 Redis 및 Spring 서버 부하 및 leaseTime 초과 여부 확인 후 조정 예정
- commit: [MutexFactory 인터페이스 생성](https://github.com/Gyu-won/Newzet-Spring-Server/commit/595ef4e0eb8da399db7f8a8c70c8d445874e1f1b), [RedisMutexFactory 구현체 생성](https://github.com/Gyu-won/Newzet-Spring-Server/commit/d45d09ec5df61e48b3fdca4c43f84017d66ee6d0)

### 3. 멀티 스레드 환경에서 동일 쿼리를 병합 처리
- 각 스레드에서 발생하는 동일한 쿼리를 ConcurrentHashMap과 CompletableFuture를 통해 하나의 쿼리로 조회된 데이터를 공유
- Live/Canary 분산 서버 환경이기 때문에 RedisMutex로 제어
- Redis 장애로 Mutex 획득 불가 시에도 데이터 저장은 필요하기 때문에 DB에서 데이터를 조회하도록 구현
  - Redis 장애는 process 재시도, docker restart, 메모리 관리로 장애 발생 확률 최소화
  -  장애가 발생하더라도 서버를 2대만 운영하기 때문에 DB 부하가 크지 않을 것으로 판단
- commit: [DistributedRequestMerger 생성](https://github.com/Gyu-won/Newzet-Spring-Server/commit/b461cb10991a7a48a2c3079df0e5e7822735d21d), [의존성 역전](https://github.com/Gyu-won/Newzet-Spring-Server/commit/1000a1aeaf79f08c9bce4d5eb183c30e004630ce)

### 4. NewsletterService에서 Cache 관련 기능 분리
- NewsletterService에서 Cache 접근 관련은 NewsletterCacheService로 분리
- commit: [NewsletterCacheService 생성](https://github.com/Gyu-won/Newzet-Spring-Server/commit/394b70a5a1646720f62f093b9cd978816d92eb02)

### 5. NewsletterService에 분산 환경에서의 쿼리 병합 전략 적용
- Redis 장애 + 중복 insert 장애는 자주 발생하지 않기 때문에 완전한 Lock을 걸기 보다는 낙관적 락으로 중복 insert 발생 시 예외처리
- commit: [병합 쿼리 전략 적용](https://github.com/Gyu-won/Newzet-Spring-Server/commit/64d77d1255d53ab4c8d9a83e6044d138dbff0951), [인자 주입 오류 수정](https://github.com/Gyu-won/Newzet-Spring-Server/commit/e568f51d0a968e69596627f05e67daaabb497be8)

## 참고자료


## 관련 이슈

close #45
