### PR TITLE
Chore: Redis 및 Caffeine의 eviction, 메모리 관리, 영속성, 리소스 제한 및 자동 재시작 설정

### DIFF
--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -3,12 +3,35 @@ services:
   redis:
     image: redis:7.0.8-alpine
     container_name: ${SPRING_REDIS_HOST}
-    command: redis-server --requirepass ${SPRING_REDIS_PASSWORD} --bind 0.0.0.0
+    command: redis-server \
+      --requirepass ${SPRING_REDIS_PASSWORD} \
+      --bind 0.0.0.0 \
+      --maxmemory 512mb \
+      --maxmemory-policy volatile-lru
+      --appendonly yes \
+      --appendfsync everysec \
+      --aof-use-rdb-preamble yes \
+      --auto-aof-rewrite-percentage 100 \
+      --auto-aof-rewrite-min-size 64mb
     ports:
       - "6379:6379"
+    restart: unless-stopped
     networks:
       - newzet-network
+    deploy:
+      resources:
+        limits:
+          memory: 600m
+    healthcheck:
+      test: ["CMD", "redis-cli, "-a", "${SPRING_REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - redis-data:/var/lib/redis
 
+volues:
+  redis-data:
 networks:
   newzet-network:
     driver: bridge

--- a/src/main/java/com/newzet/api/common/cache/local/LocalCacheUtil.java
+++ b/src/main/java/com/newzet/api/common/cache/local/LocalCacheUtil.java
@@ -1,28 +1,21 @@
 package com.newzet.api.common.cache.local;
 
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Component;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.newzet.api.common.cache.CacheUtil;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class LocalCacheUtil implements CacheUtil {
 
 	private final Cache<String, CacheEntry<?>> cache;
-
-	public LocalCacheUtil() {
-		this.cache = Caffeine.newBuilder()
-			.expireAfterWrite(10, TimeUnit.MINUTES)
-			.maximumSize(10_000)
-			.build();
-	}
 
 	@Override
 	public <T> Optional<T> get(String key, Class<T> classType) {

--- a/src/main/java/com/newzet/api/config/CaffeineConfig.java
+++ b/src/main/java/com/newzet/api/config/CaffeineConfig.java
@@ -1,0 +1,22 @@
+package com.newzet.api.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.newzet.api.common.cache.local.CacheEntry;
+
+@Configuration
+public class CaffeineConfig {
+	@Bean
+	public Cache<String, CacheEntry<?>> caffeineCache() {
+		return Caffeine.newBuilder()
+			.maximumSize(10000)
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.recordStats()
+			.build();
+	}
+}

--- a/src/main/java/com/newzet/api/config/RedisConfig.java
+++ b/src/main/java/com/newzet/api/config/RedisConfig.java
@@ -36,6 +36,7 @@ public class RedisConfig {
 		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
 			.commandTimeout(Duration.ofMillis(500))
 			.clientOptions(ClientOptions.builder()
+				.autoReconnect(true)
 				.socketOptions(SocketOptions.builder().connectTimeout(Duration.ofMillis(1000)).build())
 				.disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
 				.build())

--- a/src/test/java/com/newzet/api/common/cache/LocalCacheUtilTest.java
+++ b/src/test/java/com/newzet/api/common/cache/LocalCacheUtilTest.java
@@ -3,11 +3,16 @@ package com.newzet.api.common.cache;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.newzet.api.common.cache.local.CacheEntry;
 import com.newzet.api.common.cache.local.LocalCacheUtil;
+
 
 public class LocalCacheUtilTest {
 
@@ -15,7 +20,8 @@ public class LocalCacheUtilTest {
 
 	@BeforeEach
 	void setUp() {
-		localCacheUtil = new LocalCacheUtil();
+		Cache<String, CacheEntry<?>> cache = Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.MINUTES).build();
+		localCacheUtil = new LocalCacheUtil(cache);
 	}
 
 	@Test


### PR DESCRIPTION
# 개요

- Redis 와 Caffeine의 eviction, 메모리 관리, 영속성, 리소스 제한, 자동 재시작 설정으로 안정적인 리소스 분배 및 서버 환경 구축

# 배경

1. Redis와 Caffeine 캐시의 리소스 제한이 없어 제한 없이 리소스 사용 중이기 때문에 장애가 발생할 수 있음
2. eviction 정책을 도메인에 맞게 설정할 필요가 있음
3. 예기치 못하게 Redis 서버 다운 시 다시 재시작하는 로직이 필요했고, 이때 데이터 보존을 위해 영속성 설정이 필요함.

# 변경된 점

### Redis 
#### 1. 리소스 제한
- Redis를 실행중인 EC2 인스턴스의 메모리가 4GB인 점을 고려해 512MB로 캐시 용량 설정
  - 메모리 제한으로 인해 cache의 ttl을 짧게 유지하였기 때문에 괜찮다고 판단
- redis를 운영하는 docker 컨테이너 역시 메모리 제한 설정

#### 2. Eviction 정책 도입
- 추후 nosql 저장소로 redis를 사용할 수도 있다는 점과 뉴스레터 데이터는 짧은 시간에 중복되서 조회된다는 점을 고려해 volatile-lru eviction 정책 도입

#### 3. 장애 상황 재시작 및 영속성 설정
- redis container 자동 재시작 설정
- redis 컨테이너에서 10초 간격으로 health check를 실행하도록 설정해 장애 상황 탐지
- redis 7 이후 도입된 aof-rdb hybrid 정책으로 영속성 보장

commit: [redis 설정](https://github.com/Gyu-won/Newzet-Spring-Server/commit/c060155e63a37a517260d1fb2b249805b37f992c)

</br>

### Caffeine
#### 1. Caffeine 리소스 제한
- Caffeine 캐시는 서비스 규모를 고려해 key-value 개수를 10,000개로 설정 (모니터링을 통해 조정 예정)
- expireAfterWrite를 10분으로 설정해 데이터가 조회되지 않아 row 단위 캐시 무효화 정책이 동작하지 않을 때 만료하도록 설정
- commit: [caffeine 설정](https://github.com/Gyu-won/Newzet-Spring-Server/commit/06d96fd89251d445c0468daaab133ae6212440d7)
